### PR TITLE
Only update map if a valid ZIP entered on results

### DIFF
--- a/public/scripts/controller/resultsController.js
+++ b/public/scripts/controller/resultsController.js
@@ -10,52 +10,40 @@
     $('#form-div').show();
     $('#results').show();
     $('#results-title').show();
-  }
+  };
 
   resultsController.setZipCode = function() {
     let userZip = $('#zipInput').val();
     // Validate ZIP code entered
-    let regZip = /^\d{5}$/;
-    zipTest(userZip)
-    function zipTest(zip) {
-      let testValue = regZip.test(zip);
-      console.log(testValue);
-      if (testValue) {
+    console.log(userZip);
+    zipTest(userZip);
 
-        // Check if ZIP entered is in US, center map
+    function zipTest(zip) {
+      // Confirm a 5 digit number was entered
+      let regZip = /^\d{5}$/;
+      let regCheckOk = regZip.test(zip);
+      if (regCheckOk) {
+        // Check if ZIP entered is in US
         $.ajax({
           url: `https://maps.googleapis.com/maps/api/geocode/json?&address=${userZip}`,
-          method: 'GET'
-        })
-        .then(
-          data => {
-            let zipAddress = data.results[0].formatted_address;
-            let zipLat = data.results[0].geometry.location.lat;
-            let zipLng = data.results[0].geometry.location.lng;
-            let shortName = data.results[0].address_components[4].short_name;
-            console.log('shortName is ', shortName);
-            if (shortName !== 'US') {
-              // center map
-              // feedback message
-              console.log(`Not a US ZIP code; the closest match we found was ${zipAddress}.`);
-              return 'not found';
-            }
-          },
-          err => {console.error(err)
-          }
-        )
-
-        // If valid ZIP, request events & load results view
-        results.setLocalStorage();
-        results.getEvents(userZip, renderMapResults);
-        page('/results');
-        $('#form-div').empty();
-      } else {
-        //TODO: make a more user friendly response
-        results.handleInvalidInput();
+          method: 'GET'})
+          .then(
+            data => {
+              let shortName = data.results[0].address_components[4].short_name;
+              console.log('shortName is ', shortName);
+              // True if response is in the US, otherwise false
+              if (shortName === 'US') {
+                results.setLocalStorage();
+                results.getEvents(userZip, renderMapResults);
+                page('/results');
+                $('#form-div').empty();
+              } else {
+                results.handleInvalidInput('badZip');
+              }
+            },
+            err => console.error(err));
+        } else results.handleInvalidInput('badZip');
       }
-    }
-  }
-
+    };
   module.resultsController = resultsController;
 })(window);

--- a/public/scripts/view/homeView.js
+++ b/public/scripts/view/homeView.js
@@ -31,11 +31,16 @@ results.checkLocalStorage();
     resultsController.setZipCode();
   })
 
-results.handleInvalidInput = function() {
+results.handleInvalidInput = function(invalidReason) {
   let userZip = $('#zipInput').val();
   $('#zipInput').val('');
-  $('#zipInput').attr('placeholder', 'Not a zipcode...');
-  $('#form-div').empty().append(`"${userZip}" is not a valid zip code. Please Try again.`);
+  if(invalidReason === 'badZip') {
+      $('#zipInput').attr('placeholder', 'Not a zipcode...');
+      $('#message').text('');
+      $('#form-div').empty().append(`"${userZip}" is not a valid US zip code. Please try again.`);
+    } else {
+      console.log('No events...');
+  }
 
 }
 module.homeView = homeView;


### PR DESCRIPTION
The map was updating from the results view, even if a bad ZIP (not a
 5-digit number, or outside US) was entered.
This also clears the "[n] results found!" message if the user's next
 search is invalid, but prior map results will still persist.